### PR TITLE
feat: 集成 You.com 网络搜索功能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -107,14 +107,15 @@ GENERATE_IMAGE_MODEL   = Pollinations.AI  # not supporting DALL-E 3 yet
 #============================================================================
 # 🔎 Web Search
 #============================================================================
-WEB_SEARCH             = true   # Web Search (requires Tavily API)
-SEARCH_ENGINE          = Tavily  # currently only supports Tavily
+WEB_SEARCH             = true   # Web Search
+SEARCH_ENGINE          = Tavily  # Options: Tavily, Youcom
 
-# Search engine API keys (furture support DuckDuckGo, Bing, Google)
-TAVILY_API_KEY          = 
-#BING_API_KEY           = 
-#GOOGLE_API_KEY         = 
-#GOOGLE_CX              = 
+# Search engine API keys (Tavily, Youcom; future: Bing, Google)
+TAVILY_API_KEY          =
+YOUCOM_API_KEY          =       # https://ydc-index.io
+#BING_API_KEY           =
+#GOOGLE_API_KEY         =
+#GOOGLE_CX              =
 
 #============================================================================
 # 🔄 Auto-Reply Configuration

--- a/src/Events/AICore/utils.js
+++ b/src/Events/AICore/utils.js
@@ -448,9 +448,9 @@ async function searchWithTavily(searchConfig) {
     if (searchConfig === 'NO_SEARCH') {
         return { results: [], answer: '' };
     }
-    
+
     try {
-        const tvly = tavily({ 
+        const tvly = tavily({
             apiKey: process.env.TAVILY_API_KEY
         });
 
@@ -473,6 +473,75 @@ async function searchWithTavily(searchConfig) {
         console.error('Tavily search error:', error);
         return { results: [], answer: '' };
     }
+}
+
+const YOUCOM_SEARCH_URL = 'https://ydc-index.io/v1/search';
+
+async function searchWithYoucom(searchConfig) {
+    if (searchConfig === 'NO_SEARCH') {
+        return { results: [], answer: '' };
+    }
+
+    const apiKey = process.env.YOUCOM_API_KEY;
+    if (!apiKey) {
+        console.warn('[YoucomSearch] YOUCOM_API_KEY is not configured');
+        return { results: [], answer: '' };
+    }
+
+    try {
+        const response = await axios.post(
+            YOUCOM_SEARCH_URL,
+            {
+                query: searchConfig.query,
+                count: 10,
+            },
+            {
+                headers: {
+                    'Accept': 'application/json',
+                    'X-API-Key': apiKey,
+                },
+                timeout: 15000,
+            },
+        );
+
+        if (response.status === 429) {
+            console.warn('[YoucomSearch] Rate limit exceeded (429)');
+            return { results: [], answer: '' };
+        }
+        if (response.status === 401) {
+            console.warn('[YoucomSearch] API key invalid or expired');
+            return { results: [], answer: '' };
+        }
+        if (response.status !== 200) {
+            console.warn(`[YoucomSearch] Search failed with status ${response.status}`);
+            return { results: [], answer: '' };
+        }
+
+        const results = response.data?.results || [];
+        return {
+            results: results.map((item, index) => ({
+                title: item.title || '',
+                url: item.url || '',
+                content: Array.isArray(item.snippets) ? item.snippets[0] : (item.description || ''),
+                score: 0,
+                published_date: null,
+                raw_content: null,
+            })),
+            answer: '',
+        };
+    } catch (error) {
+        console.error('[YoucomSearch] Search error:', error.message);
+        return { results: [], answer: '' };
+    }
+}
+
+const SEARCH_ENGINE = process.env.SEARCH_ENGINE || 'Tavily';
+
+async function searchWithEngine(searchConfig) {
+    if (SEARCH_ENGINE === 'Youcom') {
+        return searchWithYoucom(searchConfig);
+    }
+    return searchWithTavily(searchConfig);
 }
 
 async function formatSearchResults(searchResults, answer) {
@@ -970,7 +1039,7 @@ async function sendStreamingResponse(message1, channel, conversationLog, modelTo
             } else {                
                 await lastMessage.edit({ content: `-# ${config.emojis.search.id ? `<a:search:${config.emojis.search.id}>` : config.emojis.search.fallback} ${getText('events.AICore.searching', contextObj, { default: '正在搜尋網路資訊' })}: ${searchQuery.query}` });
                 
-                searchResults = await searchWithTavily(searchQuery);
+                searchResults = await searchWithEngine(searchQuery);
                 
                 if (searchResults.results && searchResults.results.length > 0) {
                     const formattedResults = await formatSearchResults(searchResults.results, searchResults.answer);


### PR DESCRIPTION
## 变更内容

- 新增 `searchWithYoucom()` 函数，调用 YDC Index API (`ydc-index.io`) 实现网页搜索
- 新增 `searchWithEngine()` 分发器，根据 `SEARCH_ENGINE` 环境变量选择搜索后端（支持 Tavily / Youcom）
- `YOUCOM_API_KEY` 已添加至 `.env.example`
- 现有 Tavily 搜索保持不变，`SEARCH_ENGINE` 未配置时默认回退至 Tavily

## 使用方式

在 `.env` 中设置：
SEARCH_ENGINE=Youcom
YOUCOM_API_KEY=你的API密钥

## 测试建议

- [ ] 配置 `YOUCOM_API_KEY` 后启用 `SEARCH_ENGINE=Youcom`，验证搜索功能正常
- [ ] 验证未配置 `YOUCOM_API_KEY` 时回退至 Tavily